### PR TITLE
Delegations in client reviews july 14th, 15th

### DIFF
--- a/data/types.go
+++ b/data/types.go
@@ -262,7 +262,8 @@ func (d *DelegatedRole) MatchesPath(file string) (bool, error) {
 	return false, nil
 }
 
-// validateFields enforces the spec 1.0.19 section 4.5:
+// validateFields enforces the spec
+// https://theupdateframework.github.io/specification/v1.0.19/index.html#file-formats-targets
 // 'role MUST specify only one of the "path_hash_prefixes" or "paths"'
 // Marshalling and unmarshalling JSON will fail and return
 // ErrPathsAndPathHashesSet if both fields are set and not empty.

--- a/verify/db.go
+++ b/verify/db.go
@@ -40,7 +40,7 @@ func (d *DelegationsVerifier) Unmarshal(b []byte, v interface{}, role string, mi
 func NewDelegationsVerifier(d *data.Delegations) (DelegationsVerifier, error) {
 	db := &DB{
 		roles: make(map[string]*Role, len(d.Roles)),
-		keys:  make(map[string]*data.Key),
+		keys:  make(map[string]*data.Key, len(d.Keys)),
 	}
 	for _, r := range d.Roles {
 		role := &data.Role{Threshold: r.Threshold, KeyIDs: r.KeyIDs}

--- a/verify/verify.go
+++ b/verify/verify.go
@@ -2,6 +2,7 @@ package verify
 
 import (
 	"encoding/json"
+	"strings"
 	"time"
 
 	cjson "github.com/tent/canonical-json-go"
@@ -27,12 +28,12 @@ func (db *DB) Verify(s *data.Signed, role string, minVersion int) error {
 	if isTopLevelRole(role) {
 		// Top-level roles can only sign metadata of the same type (e.g. snapshot
 		// metadata must be signed by the snapshot role).
-		if sm.Type != role {
+		if strings.ToLower(sm.Type) != strings.ToLower(role) {
 			return ErrWrongMetaType
 		}
 	} else {
 		// Delegated (non-top-level) roles may only sign targets metadata.
-		if sm.Type != "targets" {
+		if strings.ToLower(sm.Type) != "targets" {
 			return ErrWrongMetaType
 		}
 	}


### PR DESCRIPTION
Update following review of July 15th and July 14th

[Simplify initializer ](https://github.com/raphaelgavache/go-tuf/pull/5/commits/1eefc0a5b4e141e77933eb0e45676ebc486f4462). This commit simplifies initialization of the delegations iterations and removes references to root -> topTarget 
- https://github.com/theupdateframework/go-tuf/pull/137#discussion_r670012945
- https://github.com/theupdateframework/go-tuf/pull/137#discussion_r670924427
- https://github.com/theupdateframework/go-tuf/pull/137#discussion_r670925678
- https://github.com/theupdateframework/go-tuf/pull/137#discussion_r670925995
- https://github.com/theupdateframework/go-tuf/pull/137#discussion_r670926293