### PR TITLE
Revert back to "nodes seen" interpretation of delegation traversal spec (instead of true cycle detection with "edges seen").

### DIFF
--- a/client/delegations_test.go
+++ b/client/delegations_test.go
@@ -97,7 +97,7 @@ func TestDelegationsIterator(t *testing.T) {
 				},
 			},
 			file:        "",
-			resultOrder: []string{"targets", "b", "targets", "e", "d"},
+			resultOrder: []string{"targets", "b", "d", "e"},
 		},
 		{
 			testName: "cycle avoided 2",
@@ -116,7 +116,7 @@ func TestDelegationsIterator(t *testing.T) {
 				},
 			},
 			file:        "",
-			resultOrder: []string{"targets", "targets", "b", "targets", "b", "c", "c"},
+			resultOrder: []string{"targets", "b", "c"},
 		},
 		{
 			testName: "diamond delegation",
@@ -133,7 +133,7 @@ func TestDelegationsIterator(t *testing.T) {
 				},
 			},
 			file:        "",
-			resultOrder: []string{"targets", "b", "d", "c", "d"},
+			resultOrder: []string{"targets", "b", "d", "c"},
 		},
 	}
 


### PR DESCRIPTION
As discussed offline, this is probably a mis-interpretation in ngclient (to be verified with spec owners).